### PR TITLE
Store S3 authentication details in netrc

### DIFF
--- a/bin/buckit
+++ b/bin/buckit
@@ -3,14 +3,21 @@
 require 'optparse'
 require 'methadone'
 require 'buckit'
+require File.expand_path(File.join('..', 'lib', 'buckit', 'auth'), File.dirname(__FILE__))
 
 class App
   include Methadone::Main
   include Methadone::CLILogging
+  extend Buckit::Auth
 
   main do |name|
     logger = Methadone::CLILogger.new
-    AWS.config(region: options[:region])
+
+    AWS.config(
+      region: options[:region],
+      access_key_id: auth_access_key,
+      secret_access_key: auth_access_secret,
+    )
     begin
       bucket = AWS.s3.buckets.create(name, acl: :public_read)
     rescue AWS::S3::Errors::BucketAlreadyExists => message

--- a/buckit.gemspec
+++ b/buckit.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'aruba'
   spec.add_dependency 'methadone', '~> 1.3.0'
+  spec.add_dependency 'netrc'
   spec.add_development_dependency 'rspec'
 end

--- a/lib/buckit/auth.rb
+++ b/lib/buckit/auth.rb
@@ -32,9 +32,9 @@ module Buckit
 
     def ask_for_credentials
       logger.info 'Enter your AWS key'
-      key = gets.chomp
+      key = STDIN.gets.chomp
       logger.info 'Enter your AWS secret'
-      secret = gets.chomp
+      secret = STDIN.gets.chomp
 
       [key, secret]
     end

--- a/lib/buckit/auth.rb
+++ b/lib/buckit/auth.rb
@@ -1,0 +1,70 @@
+require 'netrc'
+require 'fileutils'
+
+module Buckit
+  module Auth
+    attr_reader :credentials
+    def auth_access_key
+      get_credentials[0]
+    end
+
+    def auth_access_secret
+      get_credentials[1]
+    end
+
+    def get_credentials
+      @credentials ||= (read_credentials || ask_for_and_save_credentials)
+    end
+
+    def read_credentials
+      netrc['nl.wirelab.buckit']
+    end
+
+    def netrc_path
+      default = Netrc.default_path
+      encrypted = default + ".gpg"
+      if File.exists?(encrypted)
+        encrypted
+      else
+        default
+      end
+    end
+
+    def ask_for_credentials
+      logger.info 'Enter your AWS key'
+      key = gets.chomp
+      logger.info 'Enter your AWS secret'
+      secret = gets.chomp
+
+      [key, secret]
+    end
+
+    def ask_for_and_save_credentials
+      begin
+        @credentials = ask_for_credentials
+        write_credentials
+      end
+      @credentials
+    end
+
+    def write_credentials
+      FileUtils.mkdir_p(File.dirname(netrc_path))
+      FileUtils.touch(netrc_path)
+      netrc['nl.wirelab.buckit'] = self.credentials
+      netrc.save
+    end
+
+    def netrc
+      @netrc ||= begin
+        File.exists?(netrc_path) && Netrc.read(netrc_path)
+      rescue => error
+        if error.message =~ /^Permission bits for/
+          perm = File.stat(netrc_path).mode & 0777
+          abort("Permissions #{perm} for '#{netrc_path}' are too open. You should run `chmod 0600 #{netrc_path}` so that your credentials are NOT accessible by others.")
+        else
+          raise error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This way users won't have to add sensitive data to their ENV, and by
asking for and storing the auth details the gem becomes simpler to use.
